### PR TITLE
Name change from ApiKey to use "Token" instead.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,6 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
+    "hash": "40ea6b1f32401f2a38ee395f3340d530",
     "content-hash": "a666fb7e86531d4e241acd845bf8fc78",
     "packages": [
         {
@@ -44,7 +45,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2015-09-28T16:26:35+00:00"
+            "time": "2015-09-28 16:26:35"
         },
         {
             "name": "composer/ca-bundle",
@@ -103,20 +104,20 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-03-06T11:59:08+00:00"
+            "time": "2017-03-06 11:59:08"
         },
         {
             "name": "composer/composer",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd"
+                "reference": "489e09ee6c3ba431fbeeef9147afdaeb6f91b647"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd",
-                "reference": "7ee2a5e1cf32e9c8439445fe8dce2c046c2abebd",
+                "url": "https://api.github.com/repos/composer/composer/zipball/489e09ee6c3ba431fbeeef9147afdaeb6f91b647",
+                "reference": "489e09ee6c3ba431fbeeef9147afdaeb6f91b647",
                 "shasum": ""
             },
             "require": {
@@ -180,7 +181,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2017-03-10T08:29:45+00:00"
+            "time": "2017-05-17 06:17:53"
         },
         {
             "name": "composer/semver",
@@ -242,20 +243,20 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2016-08-30T16:08:34+00:00"
+            "time": "2016-08-30 16:08:34"
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "96c6a07b05b716e89a44529d060bc7f5c263cb13"
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/96c6a07b05b716e89a44529d060bc7f5c263cb13",
-                "reference": "96c6a07b05b716e89a44529d060bc7f5c263cb13",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
                 "shasum": ""
             },
             "require": {
@@ -303,7 +304,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2016-09-28T07:17:45+00:00"
+            "time": "2017-04-03 19:08:52"
         },
         {
             "name": "d11wtq/boris",
@@ -339,7 +340,7 @@
                 "MIT"
             ],
             "description": "A tiny, but robust REPL (Read-Evaluate-Print-Loop) for PHP.",
-            "time": "2015-03-01T08:05:19+00:00"
+            "time": "2015-03-01 08:05:19"
         },
         {
             "name": "doctrine/annotations",
@@ -407,7 +408,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-02-24T16:22:25+00:00"
+            "time": "2017-02-24 16:22:25"
         },
         {
             "name": "doctrine/cache",
@@ -477,7 +478,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
@@ -544,7 +545,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2017-01-03T10:49:41+00:00"
+            "time": "2017-01-03 10:49:41"
         },
         {
             "name": "doctrine/common",
@@ -617,7 +618,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2017-01-13T14:02:13+00:00"
+            "time": "2017-01-13 14:02:13"
         },
         {
             "name": "doctrine/dbal",
@@ -688,7 +689,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08T12:53:47+00:00"
+            "time": "2017-02-08 12:53:47"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -769,7 +770,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2017-01-16T12:01:26+00:00"
+            "time": "2017-01-16 12:01:26"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -857,7 +858,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26T17:28:51+00:00"
+            "time": "2016-01-26 17:28:51"
         },
         {
             "name": "doctrine/inflector",
@@ -924,7 +925,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06T14:35:42+00:00"
+            "time": "2015-11-06 14:35:42"
         },
         {
             "name": "doctrine/instantiator",
@@ -978,7 +979,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2015-06-14 21:17:01"
         },
         {
             "name": "doctrine/lexer",
@@ -1032,7 +1033,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "doctrine/orm",
@@ -1108,24 +1109,81 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18T15:42:34+00:00"
+            "time": "2016-12-18 15:42:34"
         },
         {
-            "name": "gedmo/doctrine-extensions",
-            "version": "v2.4.26",
+            "name": "egulias/email-validator",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
-                "reference": "983dd85d6860f87fb7dffd0d9f7ad1462e20a09d"
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "bc31baa11ea2883e017f0a10d9722ef9d50eac1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/983dd85d6860f87fb7dffd0d9f7ad1462e20a09d",
-                "reference": "983dd85d6860f87fb7dffd0d9f7ad1462e20a09d",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/bc31baa11ea2883e017f0a10d9722ef9d50eac1c",
+                "reference": "bc31baa11ea2883e017f0a10d9722ef9d50eac1c",
                 "shasum": ""
             },
             "require": {
-                "behat/transliterator": "~1.0",
+                "doctrine/lexer": "^1.0.1",
+                "php": ">= 5.5"
+            },
+            "require-dev": {
+                "dominicsayers/isemail": "dev-master",
+                "phpunit/phpunit": "^4.8.0",
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "EmailValidator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "time": "2017-01-30 22:07:36"
+        },
+        {
+            "name": "gedmo/doctrine-extensions",
+            "version": "v2.4.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
+                "reference": "58038d5d217b6ba2c75de90cb2f6d424d86fab56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/58038d5d217b6ba2c75de90cb2f6d424d86fab56",
+                "reference": "58038d5d217b6ba2c75de90cb2f6d424d86fab56",
+                "shasum": ""
+            },
+            "require": {
+                "behat/transliterator": "1.1",
                 "doctrine/common": "~2.4",
                 "php": ">=5.3.2"
             },
@@ -1133,9 +1191,8 @@
                 "doctrine/common": ">=2.5.0",
                 "doctrine/mongodb-odm": ">=1.0.2",
                 "doctrine/orm": ">=2.5.0",
-                "phpunit/phpunit": "~4.4",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "symfony/yaml": "~2.6"
+                "phpunit/phpunit": "*",
+                "symfony/yaml": "~2.6|~3.0"
             },
             "suggest": {
                 "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",
@@ -1187,7 +1244,7 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2016-12-21T13:46:54+00:00"
+            "time": "2017-04-23 08:59:41"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -1238,7 +1295,7 @@
             "keywords": [
                 "parameters management"
             ],
-            "time": "2015-11-10T17:04:01+00:00"
+            "time": "2015-11-10 17:04:01"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -1288,28 +1345,29 @@
                 "highlight",
                 "sql"
             ],
-            "time": "2014-01-12T16:20:24+00:00"
+            "time": "2014-01-12 16:20:24"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.1.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "48817e5f95c9d29e11513f12e43cc0223fa5eb6c"
+                "reference": "429be236f296ca249d61c65649cdf2652f4a5e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/48817e5f95c9d29e11513f12e43cc0223fa5eb6c",
-                "reference": "48817e5f95c9d29e11513f12e43cc0223fa5eb6c",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/429be236f296ca249d61c65649cdf2652f4a5e80",
+                "reference": "429be236f296ca249d61c65649cdf2652f4a5e80",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.1",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpdocumentor/phpdocumentor": "~2",
+                "phpdocumentor/phpdocumentor": "^2.7",
                 "phpunit/phpunit": "^4.8.22"
             },
             "bin": [
@@ -1354,7 +1412,7 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-02-22T03:28:16+00:00"
+            "time": "2017-05-16 21:06:09"
         },
         {
             "name": "lotgd/core",
@@ -1362,12 +1420,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/lotgd/core.git",
-                "reference": "03fc11477546a1518d4e4538cce9429a1d198180"
+                "reference": "bbc960fd3d721bdd40dd7d0758ab1ec0aa403a20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lotgd/core/zipball/03fc11477546a1518d4e4538cce9429a1d198180",
-                "reference": "03fc11477546a1518d4e4538cce9429a1d198180",
+                "url": "https://api.github.com/repos/lotgd/core/zipball/bbc960fd3d721bdd40dd7d0758ab1ec0aa403a20",
+                "reference": "bbc960fd3d721bdd40dd7d0758ab1ec0aa403a20",
                 "shasum": ""
             },
             "require": {
@@ -1400,10 +1458,10 @@
             ],
             "description": "Core functionality for Legend of the Green Dragon, a text-based RPG game.",
             "support": {
-                "source": "https://github.com/lotgd/core/tree/master",
+                "source": "https://github.com/lotgd/core/tree/v0.3.0-alpha",
                 "issues": "https://github.com/lotgd/core/issues"
             },
-            "time": "2017-03-13 13:13:50"
+            "time": "2017-04-25 20:31:37"
         },
         {
             "name": "lotgd/module-scene-bundle",
@@ -1411,12 +1469,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/lotgd/module-scene-bundle.git",
-                "reference": "8c219a1770f82e4799cc3369f850f577ef91cb32"
+                "reference": "e02acaf9a8d39bc114062f6eb4a0dd863833a71a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lotgd/module-scene-bundle/zipball/8c219a1770f82e4799cc3369f850f577ef91cb32",
-                "reference": "8c219a1770f82e4799cc3369f850f577ef91cb32",
+                "url": "https://api.github.com/repos/lotgd/module-scene-bundle/zipball/e02acaf9a8d39bc114062f6eb4a0dd863833a71a",
+                "reference": "e02acaf9a8d39bc114062f6eb4a0dd863833a71a",
                 "shasum": ""
             },
             "require": {
@@ -1451,7 +1509,7 @@
                 "source": "https://github.com/lotgd/module-scene-bundle/tree/master",
                 "issues": "https://github.com/lotgd/module-scene-bundle/issues"
             },
-            "time": "2017-03-13 17:31:04"
+            "time": "2017-05-20 09:35:11"
         },
         {
             "name": "lotgd/module-village",
@@ -1459,12 +1517,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/lotgd/module-village.git",
-                "reference": "d99b48468e049f07d4d6a4fd9e9204d7639114b7"
+                "reference": "f21196a09c59d290265ccdc722ddaf7b2152f1fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lotgd/module-village/zipball/d99b48468e049f07d4d6a4fd9e9204d7639114b7",
-                "reference": "d99b48468e049f07d4d6a4fd9e9204d7639114b7",
+                "url": "https://api.github.com/repos/lotgd/module-village/zipball/f21196a09c59d290265ccdc722ddaf7b2152f1fe",
+                "reference": "f21196a09c59d290265ccdc722ddaf7b2152f1fe",
                 "shasum": ""
             },
             "require": {
@@ -1494,10 +1552,10 @@
             ],
             "description": "A basic village.",
             "support": {
-                "source": "https://github.com/lotgd/module-village/tree/master",
+                "source": "https://github.com/lotgd/module-village/tree/v0.3.0-alpha",
                 "issues": "https://github.com/lotgd/module-village/issues"
             },
-            "time": "2017-03-13 14:43:11"
+            "time": "2017-04-30 12:20:42"
         },
         {
             "name": "monolog/monolog",
@@ -1575,7 +1633,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-03-13T07:08:03+00:00"
+            "time": "2017-03-13 07:08:03"
         },
         {
             "name": "overblog/graphql-bundle",
@@ -1583,49 +1641,51 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/overblog/GraphQLBundle.git",
-                "reference": "0e7ec69907dea19fa0042a841f6deaafc5b1eb28"
+                "reference": "e014e64d917459d2411896ac14b8b2065f0f399a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/overblog/GraphQLBundle/zipball/0e7ec69907dea19fa0042a841f6deaafc5b1eb28",
-                "reference": "0e7ec69907dea19fa0042a841f6deaafc5b1eb28",
+                "url": "https://api.github.com/repos/overblog/GraphQLBundle/zipball/e014e64d917459d2411896ac14b8b2065f0f399a",
+                "reference": "e014e64d917459d2411896ac14b8b2065f0f399a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/doctrine-cache-bundle": "^1.2",
                 "overblog/graphql-php-generator": "^0.4.1",
-                "php": "^5.4|~7.0",
-                "symfony/expression-language": "^2.7|^3.1",
-                "symfony/framework-bundle": "^2.7|^3.1",
-                "symfony/options-resolver": "^2.7|^3.1",
-                "symfony/property-access": "^2.7|^3.1",
+                "php": ">=5.5.9",
+                "symfony/cache": "^3.1",
+                "symfony/expression-language": "^2.8 || ^3.0",
+                "symfony/framework-bundle": "^2.8 || ^3.0",
+                "symfony/options-resolver": "^2.8 || ^3.0",
+                "symfony/property-access": "^2.8 || ^3.0",
                 "webonyx/graphql-php": "^0.9.4"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^1.11",
-                "phpunit/phpunit": "^4.1|^5.5",
+                "phpunit/phpunit": "^4.1 || ^5.5",
                 "react/promise": "^2.5",
                 "sensio/framework-extra-bundle": "^3.0",
                 "sllh/php-cs-fixer-styleci-bridge": "^1.5",
-                "symfony/asset": "^2.7|^3.1",
-                "symfony/browser-kit": "^2.7|^3.1",
-                "symfony/css-selector": "^2.7|^3.1",
-                "symfony/dependency-injection": "^2.7|^3.1",
-                "symfony/phpunit-bridge": "~2.7|^3.1",
-                "symfony/security-bundle": "^2.7|^3.1",
-                "symfony/templating": "^2.7|^3.1",
-                "symfony/twig-bundle": "^2.7|^3.1",
-                "symfony/web-profiler-bundle": "^2.7|^3.1",
-                "symfony/yaml": "^2.7|^3.1"
+                "symfony/asset": "^2.8 || ^3.0",
+                "symfony/browser-kit": "^2.8 || ^3.0",
+                "symfony/css-selector": "^2.8 || ^3.0",
+                "symfony/dependency-injection": "^2.8 || ^3.0",
+                "symfony/phpunit-bridge": "^2.8 || ^3.0",
+                "symfony/security-bundle": "^2.8 || ^3.0",
+                "symfony/templating": "^2.8 || ^3.0",
+                "symfony/twig-bundle": "^2.8 || ^3.0",
+                "symfony/web-profiler-bundle": "^2.8 || ^3.0",
+                "symfony/yaml": "^2.8 || ^3.0"
             },
             "suggest": {
+                "nelmio/cors-bundle": "For more flexibility when using CORS prefight",
                 "react/promise": "To use ReactPHP promise adapter",
                 "twig/twig": "If you want to use graphiQL."
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.8-dev"
+                    "dev-master": "0.9-dev"
                 }
             },
             "autoload": {
@@ -1651,7 +1711,7 @@
                 "Relay",
                 "graphql"
             ],
-            "time": "2017-03-13 15:49:52"
+            "time": "2017-05-11 09:50:19"
         },
         {
             "name": "overblog/graphql-php-generator",
@@ -1702,7 +1762,7 @@
                 "graphql",
                 "type"
             ],
-            "time": "2017-02-22T11:02:12+00:00"
+            "time": "2017-02-22 11:02:12"
         },
         {
             "name": "paragonie/random_compat",
@@ -1750,7 +1810,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13T16:27:32+00:00"
+            "time": "2017-03-13 16:27:32"
         },
         {
             "name": "psr/cache",
@@ -1796,7 +1856,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06T20:24:11+00:00"
+            "time": "2016-08-06 20:24:11"
         },
         {
             "name": "psr/log",
@@ -1843,20 +1903,20 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "seld/cli-prompt",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/cli-prompt.git",
-                "reference": "8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4"
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4",
-                "reference": "8cbe10923cae5bcd7c5a713f6703fc4727c8c1b4",
+                "url": "https://api.github.com/repos/Seldaek/cli-prompt/zipball/a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
+                "reference": "a19a7376a4689d4d94cab66ab4f3c816019ba8dd",
                 "shasum": ""
             },
             "require": {
@@ -1891,7 +1951,7 @@
                 "input",
                 "prompt"
             ],
-            "time": "2016-04-18T09:31:41+00:00"
+            "time": "2017-03-18 11:32:45"
         },
         {
             "name": "seld/jsonlint",
@@ -1940,7 +2000,7 @@
                 "parser",
                 "validator"
             ],
-            "time": "2017-03-06T16:42:24+00:00"
+            "time": "2017-03-06 16:42:24"
         },
         {
             "name": "seld/phar-utils",
@@ -1984,20 +2044,20 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13T18:44:15+00:00"
+            "time": "2015-10-13 18:44:15"
         },
         {
             "name": "sensio/distribution-bundle",
-            "version": "v5.0.18",
+            "version": "v5.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "17846680901003d26d823c2e3ac9228702837916"
+                "reference": "4b019d4c0bd64438c42e4b6b0726085b409be8d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/17846680901003d26d823c2e3ac9228702837916",
-                "reference": "17846680901003d26d823c2e3ac9228702837916",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/4b019d4c0bd64438c42e4b6b0726085b409be8d9",
+                "reference": "4b019d4c0bd64438c42e4b6b0726085b409be8d9",
                 "shasum": ""
             },
             "require": {
@@ -2036,20 +2096,20 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2017-01-10T14:58:45+00:00"
+            "time": "2017-05-11 16:21:03"
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.23",
+            "version": "v3.0.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "d3601fd5709168ace7a1ca6eefa2619a1632b7f7"
+                "reference": "6d6cbe971554f0a2cc84965850481eb04a2a0059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/d3601fd5709168ace7a1ca6eefa2619a1632b7f7",
-                "reference": "d3601fd5709168ace7a1ca6eefa2619a1632b7f7",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/6d6cbe971554f0a2cc84965850481eb04a2a0059",
+                "reference": "6d6cbe971554f0a2cc84965850481eb04a2a0059",
                 "shasum": ""
             },
             "require": {
@@ -2106,23 +2166,24 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-03-02T20:17:28+00:00"
+            "time": "2017-05-11 17:01:57"
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v4.0.2",
+            "version": "v4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "56bded66985e22f6eac2cf86735fd21c625bff2f"
+                "reference": "9e69eddf3bc49d1ee5c7908564da3141796d4bbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/56bded66985e22f6eac2cf86735fd21c625bff2f",
-                "reference": "56bded66985e22f6eac2cf86735fd21c625bff2f",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/9e69eddf3bc49d1ee5c7908564da3141796d4bbc",
+                "reference": "9e69eddf3bc49d1ee5c7908564da3141796d4bbc",
                 "shasum": ""
             },
             "require": {
+                "composer/ca-bundle": "^1.0",
                 "symfony/console": "~2.7|~3.0"
             },
             "bin": [
@@ -2150,33 +2211,34 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2017-03-09T17:33:20+00:00"
+            "time": "2017-03-31 14:50:32"
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.6",
+            "version": "v6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e"
+                "reference": "008f088d535ed3333af5ad804dd4c0eaf97c2805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
-                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/008f088d535ed3333af5ad804dd4c0eaf97c2805",
+                "reference": "008f088d535ed3333af5ad804dd4c0eaf97c2805",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "egulias/email-validator": "~2.0",
+                "php": ">=7.0.0"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9.1",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "~3.3@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -2204,7 +2266,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-02-13T07:52:53+00:00"
+            "time": "2017-05-20 06:20:27"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -2264,7 +2326,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2017-01-02T19:04:26+00:00"
+            "time": "2017-01-02 19:04:26"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -2317,7 +2379,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -2375,7 +2437,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2434,7 +2496,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -2490,7 +2552,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2549,7 +2611,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-util",
@@ -2601,25 +2663,25 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-11-14T01:06:16+00:00"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/swiftmailer-bundle",
-            "version": "v2.5.3",
+            "version": "v2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/swiftmailer-bundle.git",
-                "reference": "b59a70d03b948e29d070b6c4416b4a03af4748ec"
+                "reference": "a871c7294d001c81c6c30e7382c2acd70795b2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/b59a70d03b948e29d070b6c4416b4a03af4748ec",
-                "reference": "b59a70d03b948e29d070b6c4416b4a03af4748ec",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/a871c7294d001c81c6c30e7382c2acd70795b2aa",
+                "reference": "a871c7294d001c81c6c30e7382c2acd70795b2aa",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2",
-                "swiftmailer/swiftmailer": ">=4.2.0,~5.0",
+                "swiftmailer/swiftmailer": ">=4.2.0|~5.0",
                 "symfony/config": "~2.7|~3.0",
                 "symfony/dependency-injection": "~2.7|~3.0",
                 "symfony/http-kernel": "~2.7|~3.0"
@@ -2627,7 +2689,7 @@
             "require-dev": {
                 "symfony/console": "~2.7|~3.0",
                 "symfony/framework-bundle": "~2.7|~3.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
+                "symfony/phpunit-bridge": "~3.3@dev",
                 "symfony/yaml": "~2.7|~3.0"
             },
             "suggest": {
@@ -2636,7 +2698,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -2660,7 +2722,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2017-03-02T16:47:57+00:00"
+            "time": "2017-05-20 05:31:12"
         },
         {
             "name": "symfony/symfony",
@@ -2802,20 +2864,20 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-01-28T02:53:38+00:00"
+            "time": "2017-01-28 02:53:38"
         },
         {
             "name": "twig/twig",
-            "version": "v2.2.0",
+            "version": "v2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "29bb02dde09ff56291d30f7687eb8696918023af"
+                "reference": "85e8372c451510165c04bf781295f9d922fa524b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/29bb02dde09ff56291d30f7687eb8696918023af",
-                "reference": "29bb02dde09ff56291d30f7687eb8696918023af",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/85e8372c451510165c04bf781295f9d922fa524b",
+                "reference": "85e8372c451510165c04bf781295f9d922fa524b",
                 "shasum": ""
             },
             "require": {
@@ -2825,12 +2887,12 @@
             "require-dev": {
                 "psr/container": "^1.0",
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~3.2"
+                "symfony/phpunit-bridge": "~3.3@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -2865,20 +2927,20 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-02-27T00:16:20+00:00"
+            "time": "2017-04-21 00:13:02"
         },
         {
             "name": "webonyx/graphql-php",
-            "version": "v0.9.6",
+            "version": "v0.9.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "f77bd17eba9d4b2db5e128f2e943e8a577f83bf8"
+                "reference": "848f9c3edfbfbfa0903f4dd76ee2fec1cfb12224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/f77bd17eba9d4b2db5e128f2e943e8a577f83bf8",
-                "reference": "f77bd17eba9d4b2db5e128f2e943e8a577f83bf8",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/848f9c3edfbfbfa0903f4dd76ee2fec1cfb12224",
+                "reference": "848f9c3edfbfbfa0903f4dd76ee2fec1cfb12224",
                 "shasum": ""
             },
             "require": {
@@ -2910,22 +2972,22 @@
                 "api",
                 "graphql"
             ],
-            "time": "2017-03-10T12:21:27+00:00"
+            "time": "2017-04-25 11:02:45"
         }
     ],
     "packages-dev": [
         {
             "name": "liip/functional-test-bundle",
-            "version": "1.7.0",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipFunctionalTestBundle.git",
-                "reference": "8466b71c7a923295c3045b257efb53015f432ff5"
+                "reference": "fac05bc216c88e8cc855e0cd5fb3e2e81e54593a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/8466b71c7a923295c3045b257efb53015f432ff5",
-                "reference": "8466b71c7a923295c3045b257efb53015f432ff5",
+                "url": "https://api.github.com/repos/liip/LiipFunctionalTestBundle/zipball/fac05bc216c88e8cc855e0cd5fb3e2e81e54593a",
+                "reference": "fac05bc216c88e8cc855e0cd5fb3e2e81e54593a",
                 "shasum": ""
             },
             "require": {
@@ -2990,20 +3052,20 @@
             "keywords": [
                 "Symfony2"
             ],
-            "time": "2017-01-11T18:04:59+00:00"
+            "time": "2017-04-21 17:22:21"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
-                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
                 "shasum": ""
             },
             "require": {
@@ -3032,7 +3094,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-01-26T22:05:40+00:00"
+            "time": "2017-04-12 18:52:22"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3086,7 +3148,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
+            "time": "2015-12-27 11:43:31"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3131,7 +3193,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30T07:12:33+00:00"
+            "time": "2016-09-30 07:12:33"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3178,7 +3240,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25T06:54:22+00:00"
+            "time": "2016-11-25 06:54:22"
         },
         {
             "name": "phpspec/prophecy",
@@ -3241,7 +3303,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2017-03-02 20:05:34"
         },
         {
             "name": "phpunit/dbunit",
@@ -3296,20 +3358,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-02T14:39:14+00:00"
+            "time": "2016-12-02 14:39:14"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.7",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "09e2277d14ea467e5a984010f501343ef29ffc69"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/09e2277d14ea467e5a984010f501343ef29ffc69",
-                "reference": "09e2277d14ea467e5a984010f501343ef29ffc69",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
@@ -3359,7 +3421,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-01T09:12:17+00:00"
+            "time": "2017-04-02 07:44:40"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3406,7 +3468,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3447,7 +3509,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
@@ -3496,7 +3558,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2017-02-26 11:10:40"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -3545,20 +3607,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27T10:12:30+00:00"
+            "time": "2017-02-27 10:12:30"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.15",
+            "version": "5.7.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b99112aecc01f62acf3d81a3f59646700a1849e5"
+                "reference": "69c4f49ff376af2692bad9cebd883d17ebaa98a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b99112aecc01f62acf3d81a3f59646700a1849e5",
-                "reference": "b99112aecc01f62acf3d81a3f59646700a1849e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/69c4f49ff376af2692bad9cebd883d17ebaa98a1",
+                "reference": "69c4f49ff376af2692bad9cebd883d17ebaa98a1",
                 "shasum": ""
             },
             "require": {
@@ -3627,7 +3689,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-03-02T15:22:43+00:00"
+            "time": "2017-04-03 02:22:27"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3686,7 +3748,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-12-08T20:27:08+00:00"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3731,7 +3793,7 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "time": "2017-03-04 06:30:41"
         },
         {
             "name": "sebastian/comparator",
@@ -3795,27 +3857,27 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2017-01-29 09:50:25"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+                "reference": "3c7d21999e815cdfac70c6c7d79d3a9cb1bc7bc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
-                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3c7d21999e815cdfac70c6c7d79d3a9cb1bc7bc2",
+                "reference": "3c7d21999e815cdfac70c6c7d79d3a9cb1bc7bc2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
@@ -3847,7 +3909,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08T07:14:41+00:00"
+            "time": "2017-05-18 13:44:30"
         },
         {
             "name": "sebastian/environment",
@@ -3897,7 +3959,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2016-11-26 07:53:53"
         },
         {
             "name": "sebastian/exporter",
@@ -3964,7 +4026,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2016-11-19 08:54:04"
         },
         {
             "name": "sebastian/global-state",
@@ -4015,7 +4077,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2015-10-12 03:26:01"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -4061,7 +4123,7 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-02-18 15:18:39"
         },
         {
             "name": "sebastian/recursion-context",
@@ -4114,7 +4176,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2016-11-19 07:33:16"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4156,7 +4218,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2015-07-28 20:34:47"
         },
         {
             "name": "sebastian/version",
@@ -4199,20 +4261,20 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "time": "2016-10-03 07:35:21"
         },
         {
             "name": "sensio/generator-bundle",
-            "version": "v3.1.3",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioGeneratorBundle.git",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb"
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
-                "reference": "c76c7833ed5ffe0f5aeef15e13939ddb59a684eb",
+                "url": "https://api.github.com/repos/sensiolabs/SensioGeneratorBundle/zipball/37f9f4e165b033fb76cc2320838321cc57140e65",
+                "reference": "37f9f4e165b033fb76cc2320838321cc57140e65",
                 "shasum": ""
             },
             "require": {
@@ -4224,7 +4286,9 @@
             },
             "require-dev": {
                 "doctrine/orm": "~2.4",
-                "symfony/doctrine-bridge": "~2.7|~3.0"
+                "symfony/doctrine-bridge": "~2.7|~3.0",
+                "symfony/filesystem": "~2.7|~3.0",
+                "symfony/phpunit-bridge": "^3.3"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -4251,20 +4315,20 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2017-03-03T15:22:50+00:00"
+            "time": "2017-03-15 01:02:10"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.6",
+            "version": "v3.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "9103d17dd57c512a3a027bb5628f6701464d6fef"
+                "reference": "00916603c524b8048906de460b7ea0dfa1651281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/9103d17dd57c512a3a027bb5628f6701464d6fef",
-                "reference": "9103d17dd57c512a3a027bb5628f6701464d6fef",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/00916603c524b8048906de460b7ea0dfa1651281",
+                "reference": "00916603c524b8048906de460b7ea0dfa1651281",
                 "shasum": ""
             },
             "require": {
@@ -4313,7 +4377,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-03-09T12:58:16+00:00"
+            "time": "2017-04-12 14:13:17"
         },
         {
             "name": "webmozart/assert",
@@ -4363,7 +4427,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],

--- a/src/AppBundle/GraphQL/Resolver/SessionResolver.php
+++ b/src/AppBundle/GraphQL/Resolver/SessionResolver.php
@@ -24,7 +24,7 @@ class SessionResolver extends BaseManagerService implements ContainerAwareInterf
         $sessionType = new SessionType($this->getGame());
 
         if ($user instanceof User) {
-            $sessionType->setApiKey($user->getApiKey()->getApiKey());
+            $sessionType->setAuthToken($user->getApiKey()->getApiKey());
             $sessionType->setExpiresAt($user->getApiKey()->getExpiresAtAsString());
             $sessionType->setUser(new UserType($this->getGame(), $user));
         } elseif(isset($args["apiKey"])) {
@@ -36,7 +36,7 @@ class SessionResolver extends BaseManagerService implements ContainerAwareInterf
                 $user = $apiKey->getUser();
 
                 $sessionType->setUser(new UserType($this->getGame(), $user));
-                $sessionType->setApiKey($apiKey->getApiKey());
+                $sessionType->setAuthToken($apiKey->getApiKey());
                 $sessionType->setExpiresAt($apiKey->getExpiresAtAsString());
             }
         }

--- a/src/AppBundle/GraphQL/Types/SessionType.php
+++ b/src/AppBundle/GraphQL/Types/SessionType.php
@@ -39,7 +39,7 @@ class SessionType extends BaseType
      * Returns the api key
      * @return string|null
      */
-    public function getApiKey()
+    public function getAuthToken()
     {
         return $this->apiKey;
     }
@@ -48,7 +48,7 @@ class SessionType extends BaseType
      * Sets the api key to a given value.
      * @param string $apiKey
      */
-    public function setApiKey(string $apiKey)
+    public function setAuthToken(string $apiKey)
     {
         $this->apiKey = $apiKey;
     }

--- a/src/AppBundle/Resources/config/graphql/Session.types.yml
+++ b/src/AppBundle/Resources/config/graphql/Session.types.yml
@@ -3,9 +3,9 @@ Session:
     config:
         description: "Information about the current session."
         fields:
-            apiKey:
+            authToken:
                 type: "String"
-                description: "ApiKey to this realm."
+                description: "Authentification Token to this realm."
             expiresAt:
                 type: "String"
                 description: "Date this session expires at."

--- a/src/AppBundle/Security/TokenAuthenticator.php
+++ b/src/AppBundle/Security/TokenAuthenticator.php
@@ -27,7 +27,7 @@ class TokenAuthenticator implements SimplePreAuthenticatorInterface
     public function createToken(Request $request, $providerKey)
     {
         // look for a token in
-        $apiKey = $request->headers->get('token');
+        $apiKey = $request->headers->get('x-lotgd-auth-token');
 
         // no api key means still access to the page.
         if (!$apiKey) {
@@ -77,7 +77,7 @@ class TokenAuthenticator implements SimplePreAuthenticatorInterface
         if ($user === null) {
             // User not found, throw exception
             throw new AuthenticationException(
-                sprintf('API Key "%s" does not exist.', $apiKey)
+                sprintf('Session Authentication Token "%s" does not exist.', $apiKey)
             );
         }
 

--- a/tests/Functional/GraphQL/AuthWithPasswordMutationTest.php
+++ b/tests/Functional/GraphQL/AuthWithPasswordMutationTest.php
@@ -13,7 +13,7 @@ class AuthWithPasswordMutationTest extends GraphQLTestCase
 mutation AuthWithPasswordMutation($input: AuthWithPasswordInput!) {
   authWithPassword(input: $input) {
     session {
-        apiKey,
+        authToken,
         expiresAt,
         user {
             id,
@@ -65,7 +65,7 @@ JSON;
 mutation AuthWithPasswordMutation($input: AuthWithPasswordInput!) {
   authWithPassword(input: $input) {
     session {
-        apiKey,
+        authToken,
         expiresAt,
         user {
             id,
@@ -94,7 +94,7 @@ JSON;
         $this->assertArrayHasKey("clientMutationId", $result["data"]["authWithPassword"]);
         $this->assertArrayHasKey("session", $result["data"]["authWithPassword"]);
 
-        $this->assertArrayHasKey("apiKey", $result["data"]["authWithPassword"]["session"]);
+        $this->assertArrayHasKey("authToken", $result["data"]["authWithPassword"]["session"]);
         $this->assertArrayHasKey("expiresAt", $result["data"]["authWithPassword"]["session"]);
         $this->assertArrayHasKey("user", $result["data"]["authWithPassword"]["session"]);
         $this->assertArrayHasKey("id", $result["data"]["authWithPassword"]["session"]["user"]);
@@ -112,7 +112,7 @@ JSON;
 mutation AuthWithPasswordMutation($input: AuthWithPasswordInput!) {
   authWithPassword(input: $input) {
     session {
-        apiKey,
+        authToken,
         expiresAt,
         user {
             id,

--- a/tests/Functional/GraphQL/AuthWithSessionAuthenticationTokenTest.php
+++ b/tests/Functional/GraphQL/AuthWithSessionAuthenticationTokenTest.php
@@ -5,7 +5,7 @@ namespace LotGD\Crate\GraphQL\Tests\Functional\GraphQL;
 
 use LotGD\Crate\GraphQL\Models\User;
 
-class AuthWithApiKeyTest extends GraphQLTestCase
+class AuthWithSessionAuthenticationTokenTest extends GraphQLTestCase
 {
     public function testWithValidAuthData()
     {
@@ -75,7 +75,7 @@ GraphQL;
             ],
             "server" => [
                 "CONTENT_TYPE" => "application/graphql",
-                "HTTP_TOKEN" => $apiKey,
+                "HTTP_X_LOTGD_AUTH_TOKEN" => $apiKey,
             ]
         ]);
 
@@ -163,11 +163,11 @@ GraphQL;
             ],
             "server" => [
                 "CONTENT_TYPE" => "application/graphql",
-                "HTTP_TOKEN" => $apiKey,
+                "HTTP_X_LOTGD_AUTH_TOKEN" => $apiKey,
             ]
         ]);
 
         $this->assertStatusCode(401, $client);
-        $this->assertJsonStringEqualsJsonString('{"error":["API Key \u0022HuLaLa\u0022 does not exist."]}', $client->getResponse()->getContent());
+        $this->assertJsonStringEqualsJsonString('{"error":["Session Authentication Token \u0022HuLaLa\u0022 does not exist."]}', $client->getResponse()->getContent());
     }
 }

--- a/tests/Functional/GraphQL/AuthWithSessionAuthenticationTokenTest.php
+++ b/tests/Functional/GraphQL/AuthWithSessionAuthenticationTokenTest.php
@@ -14,7 +14,7 @@ class AuthWithSessionAuthenticationTokenTest extends GraphQLTestCase
 mutation AuthWithPasswordMutation($input: AuthWithPasswordInput!) {
   authWithPassword(input: $input) {
     session {
-        apiKey,
+        authToken,
         expiresAt,
         user {
             id,
@@ -41,7 +41,7 @@ JSON;
         $this->assertSame("avcd", $answer["data"]["authWithPassword"]["clientMutationId"]);
         $this->assertArrayHasKey("session", $answer["data"]["authWithPassword"]);
 
-        $apiKey = $answer["data"]["authWithPassword"]["session"]["apiKey"];
+        $apiKey = $answer["data"]["authWithPassword"]["session"]["authToken"];
 
         $query = <<<GraphQL
 query RealmQuery {
@@ -103,7 +103,7 @@ GraphQL;
 mutation AuthWithPasswordMutation($input: AuthWithPasswordInput!) {
   authWithPassword(input: $input) {
     session {
-        apiKey,
+        authToken,
         expiresAt,
         user {
             id,

--- a/tests/Functional/GraphQL/GraphQLTestCase.php
+++ b/tests/Functional/GraphQL/GraphQLTestCase.php
@@ -36,7 +36,7 @@ class GraphQLTestCase extends WebTestCase
 
         $headers = ['CONTENT_TYPE' => 'application/graphql'];
         if ($apiKey) {
-            $headers["HTTP_TOKEN"] = $apiKey;
+            $headers["HTTP_X_LOTGD_AUTH_TOKEN"] = $apiKey;
         }
 
         $client->request(

--- a/tests/Resolver/SessionResolverTest.php
+++ b/tests/Resolver/SessionResolverTest.php
@@ -53,7 +53,7 @@ class SessionResolverTest extends WebTestCase
 
         $this->assertInstanceOf(SessionType::class, $type);
         $this->assertNull($type->getUser());
-        $this->assertNull($type->getApiKey());
+        $this->assertNull($type->getAuthToken());
         $this->assertNull($type->getExpiresAt());
     }
 
@@ -70,7 +70,7 @@ class SessionResolverTest extends WebTestCase
         $type = $resolver->resolve();
 
         $this->assertInstanceOf(SessionType::class, $type);
-        $this->assertEquals("apiKey", $type->getApiKey());
+        $this->assertEquals("apiKey", $type->getAuthToken());
         $this->assertEquals("Expires In 2017", $type->getExpiresAt());
         $this->assertEquals(12345, $type->getUser()->getId());
     }
@@ -84,7 +84,7 @@ class SessionResolverTest extends WebTestCase
         $type = $resolver->resolve($args);
 
         $this->assertInstanceOf(SessionType::class, $type);
-        $this->assertEquals("c4fEAJLQlaV/47UZl52nAQ==", $type->getApiKey());
+        $this->assertEquals("c4fEAJLQlaV/47UZl52nAQ==", $type->getAuthToken());
         $this->assertEquals("2999-12-31T23:59:59+00:00", $type->getExpiresAt());
         $this->assertEquals(2, $type->getUser()->getId());
     }

--- a/tests/Types/SessionTypeTest.php
+++ b/tests/Types/SessionTypeTest.php
@@ -36,9 +36,9 @@ class SessionTypeTest extends WebTestCase
         $type = new SessionType($this->getGameMock());
         $apiKey = "asdasdasde2q3sfds";
 
-        $this->assertNull($type->getApiKey());
-        $type->setApiKey($apiKey);
-        $this->assertSame($apiKey, $type->getApiKey());
+        $this->assertNull($type->getAuthToken());
+        $type->setAuthToken($apiKey);
+        $this->assertSame($apiKey, $type->getAuthToken());
     }
 
     public function testSetAndGetExpirationDate()

--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -634,12 +634,6 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRecommendation(
-            function_exists('iconv'),
-            'iconv() should be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
-
-        $this->addRecommendation(
             function_exists('utf8_decode'),
             'utf8_decode() should be available',
             'Install and enable the <strong>XML</strong> extension.'

--- a/web/config.php
+++ b/web/config.php
@@ -11,7 +11,7 @@
  */
 
 if (!isset($_SERVER['HTTP_HOST'])) {
-    exit('This script cannot be run from the CLI. Run it from a browser.');
+    exit("This script cannot be run from the CLI. Run it from a browser.\n");
 }
 
 if (!in_array(@$_SERVER['REMOTE_ADDR'], array(


### PR DESCRIPTION
As requested, this update renamed the use of "ApiKey" for http authentification to reflect more it's use as a token.
This also changes the header used for authentification mechanisms:

Instead of using ApiKey, it uses now X-LotGD-Auth-Token instead.

This PR fixes #32 and #34 