### PR TITLE
CreatePasswordUserPayload now returns session

### DIFF
--- a/src/AppBundle/GraphQL/Mutation/AuthMutation.php
+++ b/src/AppBundle/GraphQL/Mutation/AuthMutation.php
@@ -97,6 +97,7 @@ class AuthMutation implements EntityManagerAwareInterface
             throw new UserError("An unknown exception occured: " . $ex->getMessage());
         }
 
-        return [];
+        // @ToDo add check to only return session if server settings allow this without email validation.
+        return $this->authWithPassword($email, $password);
     }
 }

--- a/src/AppBundle/Resources/config/graphql/Mutations/CreatePasswordUser.types.yml
+++ b/src/AppBundle/Resources/config/graphql/Mutations/CreatePasswordUser.types.yml
@@ -18,3 +18,6 @@ CreatePasswordUserPayload:
     description: "Payload to access information for a freshly created user."
     config:
         fields:
+            session:
+                description: "The newly created session if the server allows registration without email validation."
+                type: "Session"

--- a/tests/Functional/GraphQL/CreatePasswordUserTest.php
+++ b/tests/Functional/GraphQL/CreatePasswordUserTest.php
@@ -176,4 +176,36 @@ JSON;
         $this->assertQuery($query, $answer1, $variables1);
         $this->assertQuery($query, $answer2, $variables2);
     }
+
+    public function testIfCharacterCreationReturnsSession()
+    {
+        $query = <<<'EOF'
+mutation CreatePasswordUserMutation($input: CreatePasswordUserInput!) {
+  createPasswordUser(input: $input) {
+    clientMutationId,
+    session {
+        authToken
+    }
+  }
+}
+EOF;
+
+        $variables = <<<JSON
+{
+  "input": {
+    "name": "test",
+    "email": "email@example.com",
+    "password": "test",
+    "clientMutationId": "ijhdioasd"
+  }
+}
+JSON;
+
+        $answer = $this->getQueryResults($query, $variables);
+
+        $this->assertSame("ijhdioasd", $answer["data"]["createPasswordUser"]["clientMutationId"]);
+        $this->assertNotEmpty($answer["data"]["createPasswordUser"]["session"]);
+        $this->assertArrayHasKey("authToken", $answer["data"]["createPasswordUser"]["session"]);
+        $this->assertNotEmpty($answer["data"]["createPasswordUser"]["session"]["authToken"]);
+    }
 }


### PR DESCRIPTION
Session field on CreatePasswordUserPayload is optional, meaning servers
do not need to return it. This allows servers later to activate or
deactivate this behaviour if email addresses need to get confirmed first
before loging in.

Fixes #33