### PR TITLE
Characters cannot be created with empty name

### DIFF
--- a/src/AppBundle/GraphQL/Mutation/CharacterMutation.php
+++ b/src/AppBundle/GraphQL/Mutation/CharacterMutation.php
@@ -3,19 +3,19 @@ declare(strict_types=1);
 
 namespace LotGD\Crate\GraphQL\AppBundle\GraphQL\Mutation;
 
-use LotGD\Core\PermissionManager;
 use Overblog\GraphQLBundle\Definition\Argument;
 use Overblog\GraphQLBundle\Error\UserError;
 
+use LotGD\Core\PermissionManager;
+use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Crate\GraphQL\AppBundle\GraphQL\Connections\CharacterConnection;
 use LotGD\Crate\GraphQL\AppBundle\GraphQL\Types\CharacterType;
 use LotGD\Crate\GraphQL\AppBundle\GraphQL\Types\UserType;
+use LotGD\Crate\GraphQL\Exceptions\CharacterNameExistsException;
 use LotGD\Crate\GraphQL\Services\BaseManagerService;
 use LotGD\Crate\GraphQL\Tools\EntityManagerAwareInterface;
 use LotGD\Crate\GraphQL\Tools\EntityManagerAwareTrait;
 use LotGD\Crate\GraphQL\Tools\ManagerAwareTrait;
-
-use LotGD\Crate\GraphQL\Exceptions\CharacterNameExistsException;
 
 
 /**
@@ -55,7 +55,7 @@ class CharacterMutation extends BaseManagerService implements EntityManagerAware
         try {
             $character = $this->getCharacterManager()->createNewCharacter($characterName);
             $user->addCharacter($character);
-        } catch(CharacterNameExistsException $e) {
+        } catch(CharacterNameExistsException | ArgumentException $e) {
             throw new UserError($e->getMessage());
         }
 

--- a/src/Services/CharacterManagerService.php
+++ b/src/Services/CharacterManagerService.php
@@ -34,7 +34,7 @@ class CharacterManagerService extends BaseManagerService
         }
 
         // Remove special characters and check if it is still the same name
-        $name_sanitized = preg_replace("/[^\\p{L} ]/u", "", $name);
+        $name_sanitized = preg_replace("/[\\p{C}]/u", "", $name);
 
         if ($name != $name_sanitized) {
             throw new ArgumentException("Character name must only contain letters and spaces.");

--- a/src/Services/CharacterManagerService.php
+++ b/src/Services/CharacterManagerService.php
@@ -6,6 +6,7 @@ namespace LotGD\Crate\GraphQL\Services;
 use Exception;
 use Doctrine\DBAL\DBALException;
 
+use LotGD\Core\Exceptions\ArgumentException;
 use LotGD\Core\Models\Character;
 use LotGD\Crate\GraphQL\Exceptions\CharacterNameExistsException;
 use LotGD\Crate\GraphQL\Exceptions\CrateException;
@@ -16,14 +17,29 @@ use LotGD\Crate\GraphQL\Exceptions\CrateException;
 class CharacterManagerService extends BaseManagerService
 {
     /**
-     * Creates a new character
+     * Creates a new character.
      * @param string $name
      * @return Character
+     * @throws ArgumentException If character name is invalid
      * @throws CharacterNameExistsException If character is already taken
-     * @throws CrateException If some unknown character occured during saving.
+     * @throws CrateException If some unknown character occured during saving
      */
     public function createNewCharacter(string $name): Character
     {
+        // Remove whitespace
+        $name = trim($name);
+
+        if (empty($name)) {
+            throw new ArgumentException("Character name must not be empty.");
+        }
+
+        // Remove special characters and check if it is still the same name
+        $name_sanitized = preg_replace("/[^\\p{L} ]/u", "", $name);
+
+        if ($name != $name_sanitized) {
+            throw new ArgumentException("Character name must only contain letters and spaces.");
+        }
+
         $character = $this->findByName($name);
 
         if ($character) {

--- a/tests/Functional/GraphQL/CharacterMutationTest.php
+++ b/tests/Functional/GraphQL/CharacterMutationTest.php
@@ -94,6 +94,27 @@ JSON;
         $this->assertQueryAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $answer, $variables);
     }
 
+    public function testIfCharacterCreationFailsIfNameIsInvalid()
+    {
+        $mutation = $this->getSimpleCreationMutation();
+
+        $variables = $this->getSimpleCreationMutationInput(2, "", "asd789g7");
+        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+        $this->assertSame("Character name must not be empty.", $answer["errors"][0]["message"]);
+
+        $variables = $this->getSimpleCreationMutationInput(2, "** Bin der beste ***", "asd789g7");
+        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+
+        $variables = $this->getSimpleCreationMutationInput(2, "L33ker", "asd789g7");
+        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+
+        $variables = $this->getSimpleCreationMutationInput(2, ".matic", "asd789g7");
+        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+    }
+
     public function testIfCharacterCreationFailsIfUserIsNotLoggedIn()
     {
         $mutation = $this->getSimpleCreationMutation();

--- a/tests/Functional/GraphQL/CharacterMutationTest.php
+++ b/tests/Functional/GraphQL/CharacterMutationTest.php
@@ -102,17 +102,31 @@ JSON;
         $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
         $this->assertSame("Character name must not be empty.", $answer["errors"][0]["message"]);
 
-        $variables = $this->getSimpleCreationMutationInput(2, "** Bin der beste ***", "asd789g7");
-        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
-        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+        // List of names that must not pass
+        $list = [
+            "A\\rB",
+            "Danny\\n O' Melly",
+            "Tab\\t McTabby",
+        ];
 
-        $variables = $this->getSimpleCreationMutationInput(2, "L33ker", "asd789g7");
-        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
-        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+        foreach ($list as $name) {
+            $variables = $this->getSimpleCreationMutationInput(2, $name, "asd789g7");
+            $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+            $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+        }
 
-        $variables = $this->getSimpleCreationMutationInput(2, ".matic", "asd789g7");
-        $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
-        $this->assertSame("Character name must only contain letters and spaces.", $answer["errors"][0]["message"]);
+        // List of names that must pass
+        $pass = [
+            "Danny O' Melly",
+            "L337 Hack0rz",
+            "David",
+        ];
+
+        foreach ($pass as $name) {
+            $variables = $this->getSimpleCreationMutationInput(2, $name, "asd789g7");
+            $answer = $this->getQueryResultsAuthorized("c4fEAJLQlaV/47UZl52nAQ==", $mutation, $variables);
+            $this->assertArrayNotHasKey("errors", $answer);
+        }
     }
 
     public function testIfCharacterCreationFailsIfUserIsNotLoggedIn()


### PR DESCRIPTION
Additionally, character names not containing letters and spaces only are
rejected as well.

Fixes #36